### PR TITLE
Fix for incorrect Norwegian currency enum and invoice days enum on older invoices

### DIFF
--- a/Harvest.Net/Models/Enumerations.cs
+++ b/Harvest.Net/Models/Enumerations.cs
@@ -18,7 +18,7 @@ namespace Harvest.Net.Models
         [Description("New Zealand Dollar - NZD")]NZD,
         [Description("Swedish krona - SEK")]SEK,
         [Description("Danish Krone - DKK")]DKK,
-        [Description("Norway Kroner - NOK")]NOK,
+        [Description("Norwegian Krone - NOK")]NOK,
         [Description("Switzerland Franc - CHF")]CHF,
         [Description("South Africa Rand - ZAR")]ZAR,
         [Description("Afghanistan Afghani - AFN")]AFN,

--- a/Harvest.Net/Serialization/HarvestXmlDeserializer.cs
+++ b/Harvest.Net/Serialization/HarvestXmlDeserializer.cs
@@ -147,7 +147,10 @@ namespace Harvest.Net.Serialization
                     if (match != null)
                         prop.SetValue(x, match, null);
                     else
+                    {
+                        if (value.ToString() == "30 days") value = "net30";
                         prop.SetValue(x, type.FindEnumValue(value.ToString(), Culture), null);
+                    }
                 }
                 else if (type == typeof(Uri))
                 {


### PR DESCRIPTION
When selecting norwegian currency, the enum in the API is incorrect causing the xml deserialization to fail.

The InvoiceDateAtFormat enum uses the "net30" format, while some older orders return "30 days" in the xml, causing the xml deserialization to fail.