### PR TITLE
Fixed Description for GPB currency

### DIFF
--- a/Harvest.Net/Models/Enumerations.cs
+++ b/Harvest.Net/Models/Enumerations.cs
@@ -12,7 +12,7 @@ namespace Harvest.Net.Models
     {
         [Description("United States Dollar - USD")]USD,
         [Description("Euro - EUR")]EUR,
-        [Description("United Kingdom Pound - GBP")]GBP,
+        [Description("British Pound - GBP")]GBP,
         [Description("Canadian Dollar - CAD")]CAD,
         [Description("Australia Dollar - AUD")]AUD,
         [Description("New Zealand Dollar - NZD")]NZD,


### PR DESCRIPTION
It appears that the name for GBP in harvest has changed from
United Kingdom Pound - GBP
to
British Pound - GBP

This commit fixes an error when the currency is GBP for a client.